### PR TITLE
fix memory leak

### DIFF
--- a/source/kpp_integrate_cuda_prototype.cu
+++ b/source/kpp_integrate_cuda_prototype.cu
@@ -696,7 +696,7 @@ void Rosenbrock(double * __restrict__ conc, const double Tstart, const double Te
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;

--- a/source/rodas3.cu
+++ b/source/rodas3.cu
@@ -283,7 +283,7 @@ void Rosenbrock_rodas3(double * __restrict__ conc, const double Tstart, const do
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;

--- a/source/rodas4.cu
+++ b/source/rodas4.cu
@@ -295,7 +295,7 @@ void Rosenbrock_rodas4(double * __restrict__ conc, const double Tstart, const do
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;

--- a/source/ros2.cu
+++ b/source/ros2.cu
@@ -196,7 +196,7 @@ void Rosenbrock_ros2(double * __restrict__ conc, const double Tstart, const doub
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;

--- a/source/ros3.cu
+++ b/source/ros3.cu
@@ -208,7 +208,7 @@ void Rosenbrock_ros3(double * __restrict__ conc, const double Tstart, const doub
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;

--- a/source/ros4.cu
+++ b/source/ros4.cu
@@ -270,7 +270,7 @@ void Rosenbrock_ros4(double * __restrict__ conc, const double Tstart, const doub
     double *varErr = &d_varErr[index*NVAR];
 
     /* Temporary arrays allocated in stack */
-    double var_stack[NVAR];
+    double var_stack[NSPEC];
     double fix_stack[NFIX];
     double rconst_stack[NREACT];
     double *var    = var_stack;


### PR DESCRIPTION
fix memory leak:
 var is initialized using NSPEC and and  NSPEC > NVAR

 for (int i=0; i<NSPEC; i++)
            var(index,i) = conc(index,i);
