### PR TITLE
Adding streams to medina

### DIFF
--- a/f2c_alpha.py
+++ b/f2c_alpha.py
@@ -862,7 +862,7 @@ def generate_special_ros_caller(ros):
 
     roscall = []
 
-    default_call = '      Rosenbrock<<<dimGrid,dimBlock, 0, stream[i]>>>(d_conc, Tstart, Tend, d_rstatus, d_istatus,\n\
+    default_call = '      Rosenbrock<<<nBlocks,dimBlock, 0, stream[i]>>>(d_conc, Tstart, Tend, d_rstatus, d_istatus,\n\
                     // values calculated from icntrl and rcntrl at host\n\
                     autonomous, vectorTol, UplimTol, method, Max_no_steps,\n\
                     d_jac0, d_Ghimj,d_varNew, d_K, d_varErr, d_dFdT, d_Fcn0, d_var, d_fix, d_rconst,\n\

--- a/f2c_alpha.py
+++ b/f2c_alpha.py
@@ -862,7 +862,7 @@ def generate_special_ros_caller(ros):
 
     roscall = []
 
-    default_call = '      Rosenbrock<<<dimGrid,dimBlock>>>(d_conc, Tstart, Tend, d_rstatus, d_istatus,\n\
+    default_call = '      Rosenbrock<<<dimGrid,dimBlock, 0, stream[i]>>>(d_conc, Tstart, Tend, d_rstatus, d_istatus,\n\
                     // values calculated from icntrl and rcntrl at host\n\
                     autonomous, vectorTol, UplimTol, method, Max_no_steps,\n\
                     d_jac0, d_Ghimj,d_varNew, d_K, d_varErr, d_dFdT, d_Fcn0, d_var, d_fix, d_rconst,\n\
@@ -873,7 +873,7 @@ def generate_special_ros_caller(ros):
                     // Global input arrays\n\
                     temp_gpu, press_gpu, cair_gpu, \n\
                     // extra - vector lenght and processor\n\
-                    VL_GLO); '
+                    VL_GLO, offset); '
 
     if ( ros == '2'):
         rosscall = '     switch (method){\n\

--- a/source/kpp_integrate_cuda_prototype.cu
+++ b/source/kpp_integrate_cuda_prototype.cu
@@ -925,7 +925,7 @@ __global__ void reduce_istatus_2(int4 *tmp_out_1, int4 *tmp_out_2, int *out)
 
 /* Assuming different processes */
 enum { TRUE=1, FALSE=0 } ;
-double *d_conc, *d_temp, *d_press, *d_cair, *d_khet_st, *d_khet_tr, *d_jx, *d_jac0, *d_Ghimj, *d_varNew, *d_K, *d_varErr, *d_dFdT, *d_Fcn0, *d_var, *d_fix, *d_rconst;
+double *d_conc, *d_khet_st, *d_khet_tr, *d_jx, *d_jac0, *d_Ghimj, *d_varNew, *d_K, *d_varErr, *d_dFdT, *d_Fcn0, *d_var, *d_fix, *d_rconst;
 int initialized = FALSE;
 
 /* Device pointers pointing to GPU */
@@ -989,9 +989,6 @@ __host__ void init_first_time(int pe, int VL_GLO, int size_khet_st, int size_khe
 extern "C" void finalize_cuda(){
     /* Free memory on the device */
     gpuErrchk( cudaFree(d_conc        ) );
-    gpuErrchk( cudaFree(d_temp        ) );
-    gpuErrchk( cudaFree(d_press       ) );
-    gpuErrchk( cudaFree(d_cair        ) );
     gpuErrchk( cudaFree(d_khet_st     ) );
     gpuErrchk( cudaFree(d_khet_tr     ) );
     gpuErrchk( cudaFree(d_jx          ) );

--- a/source/rodas3.cu
+++ b/source/rodas3.cu
@@ -14,9 +14,10 @@ __device__  static  int ros_Integrator_rodas3(double * __restrict__ var, const d
         const double * __restrict__ khet_st, const double * __restrict__ khet_tr,
         const double * __restrict__ jx,
         // VL_GLO
-        const int VL_GLO)
+        const int VL_GLO,
+        const int offset )
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x+offset;
 
     double H, Hnew, HC, HG, Fac; // Tau - not used
     double Err; //*varErr;

--- a/source/rodas3.cu
+++ b/source/rodas3.cu
@@ -263,9 +263,9 @@ void Rosenbrock_rodas3(double * __restrict__ conc, const double Tstart, const do
                 const double * __restrict__ temp_gpu,
                 const double * __restrict__ press_gpu,
                 const double * __restrict__ cair_gpu,
-                const int VL_GLO)
+                const int VL_GLO, const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x+offset;
 
 
     /* 
@@ -329,7 +329,7 @@ void Rosenbrock_rodas3(double * __restrict__ conc, const double Tstart, const do
         for (int i=0; i<NFIX; i++)
             fix(index,i) = conc(index,NVAR+i);
 
-        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO); 
+        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO, offset); 
 
         ros_Integrator_rodas3(var, fix, Tstart, Tend, Texit,
                 //  Integration parameters
@@ -343,7 +343,7 @@ void Rosenbrock_rodas3(double * __restrict__ conc, const double Tstart, const do
                 K, dFdT, jac0, Ghimj,  varErr, 
                 // For update rconst
                 khet_st, khet_tr, jx,
-                VL_GLO
+                VL_GLO, offset
                 );
 
         for (int i=0; i<NVAR; i++)

--- a/source/rodas4.cu
+++ b/source/rodas4.cu
@@ -275,9 +275,9 @@ void Rosenbrock_rodas4(double * __restrict__ conc, const double Tstart, const do
                 const double * __restrict__ temp_gpu,
                 const double * __restrict__ press_gpu,
                 const double * __restrict__ cair_gpu,
-                const int VL_GLO)
+                const int VL_GLO, const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x + offset;
 
 
     /* 
@@ -330,7 +330,7 @@ void Rosenbrock_rodas4(double * __restrict__ conc, const double Tstart, const do
         for (int i=0; i<NFIX; i++)
             fix(index,i) = conc(index,NVAR+i);
 
-        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO); 
+        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO, offset); 
 
         ros_Integrator_rodas4(var, fix, Tstart, Tend, Texit,
                 //  Integration parameters
@@ -344,7 +344,7 @@ void Rosenbrock_rodas4(double * __restrict__ conc, const double Tstart, const do
                 K, dFdT, jac0, Ghimj,  varErr, 
                 // For update rconst
                 khet_st, khet_tr, jx,
-                VL_GLO
+                VL_GLO, offset
                 );
 
         for (int i=0; i<NVAR; i++)

--- a/source/rodas4.cu
+++ b/source/rodas4.cu
@@ -13,9 +13,10 @@ __device__  static  int ros_Integrator_rodas4(double * __restrict__ var, const d
         const double * __restrict__ khet_st, const double * __restrict__ khet_tr,
         const double * __restrict__ jx,
         // VL_GLO
-        const int VL_GLO)
+        const int VL_GLO,
+        const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x+offset;
 
     double H, Hnew, HC, HG, Fac; // Tau - not used
     double Err; //*varErr;

--- a/source/ros2.cu
+++ b/source/ros2.cu
@@ -14,9 +14,10 @@ __device__  static  int ros_Integrator_ros2(double * __restrict__ var, const dou
         const double * __restrict__ khet_st, const double * __restrict__ khet_tr,
         const double * __restrict__ jx,
         // VL_GLO
-        const int VL_GLO)
+        const int VL_GLO, 
+        const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x+offset;
 
     double H, Hnew, HC, HG, Fac; // Tau - not used
     double Err; //*varErr;

--- a/source/ros2.cu
+++ b/source/ros2.cu
@@ -176,9 +176,9 @@ void Rosenbrock_ros2(double * __restrict__ conc, const double Tstart, const doub
                 const double * __restrict__ temp_gpu,
                 const double * __restrict__ press_gpu,
                 const double * __restrict__ cair_gpu,
-                const int VL_GLO)
+                const int VL_GLO, const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x + offset;
 
 
     /* 
@@ -229,7 +229,7 @@ void Rosenbrock_ros2(double * __restrict__ conc, const double Tstart, const doub
         for (int i=0; i<NFIX; i++)
             fix(index,i) = conc(index,NVAR+i);
 
-        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO); 
+        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO, offset); 
 
         ros_Integrator_ros2(var, fix, Tstart, Tend, Texit,
                 //  Integration parameters
@@ -243,7 +243,7 @@ void Rosenbrock_ros2(double * __restrict__ conc, const double Tstart, const doub
                 K, dFdT, jac0, Ghimj,  varErr, 
                 // For update rconst
                 khet_st, khet_tr, jx,
-                VL_GLO
+                VL_GLO, offset
                 );
 
         for (int i=0; i<NVAR; i++)

--- a/source/ros3.cu
+++ b/source/ros3.cu
@@ -13,9 +13,10 @@ __device__ static int ros_Integrator_ros3(double * __restrict__ var, const doubl
         const double * __restrict__ khet_st, const double * __restrict__ khet_tr,
         const double * __restrict__ jx,
         // VL_GLO
-        const int VL_GLO)
+        const int VL_GLO,
+        const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x+offset;
 
     double H, Hnew, HC, HC0,HC1, HG, Fac; // Tau - not used
     double Err; //*varErr;

--- a/source/ros3.cu
+++ b/source/ros3.cu
@@ -188,9 +188,9 @@ void Rosenbrock_ros3(double * __restrict__ conc, const double Tstart, const doub
                 const double * __restrict__ temp_gpu,
                 const double * __restrict__ press_gpu,
                 const double * __restrict__ cair_gpu,
-                const int VL_GLO)
+                const int VL_GLO, const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x + offset;
 
 
     /* 
@@ -243,7 +243,7 @@ void Rosenbrock_ros3(double * __restrict__ conc, const double Tstart, const doub
         for (int i=0; i<NFIX; i++)
             fix(index,i) = conc(index,NVAR+i);
 
-        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO); 
+        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO, offset); 
 
         ros_Integrator_ros3(var, fix, Tstart, Tend, Texit,
                 //  Integration parameters
@@ -257,7 +257,7 @@ void Rosenbrock_ros3(double * __restrict__ conc, const double Tstart, const doub
                 K, dFdT, jac0, Ghimj,  varErr, 
                 // For update rconst
                 khet_st, khet_tr, jx,
-                VL_GLO
+                VL_GLO, offset
                 );
 
         for (int i=0; i<NVAR; i++)

--- a/source/ros4.cu
+++ b/source/ros4.cu
@@ -13,9 +13,10 @@ __device__  static  int ros_Integrator_ros4(double * __restrict__ var, const dou
         const double * __restrict__ khet_st, const double * __restrict__ khet_tr,
         const double * __restrict__ jx,
         // VL_GLO
-        const int VL_GLO)
+        const int VL_GLO,
+        const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x + offset;
 
     double H, Hnew, HC, HG, Fac; // Tau - not used
     double Err; //*varErr;

--- a/source/ros4.cu
+++ b/source/ros4.cu
@@ -250,9 +250,9 @@ void Rosenbrock_ros4(double * __restrict__ conc, const double Tstart, const doub
                 const double * __restrict__ temp_gpu,
                 const double * __restrict__ press_gpu,
                 const double * __restrict__ cair_gpu,
-                const int VL_GLO)
+                const int VL_GLO, const int offset)
 {
-    int index = blockIdx.x*blockDim.x+threadIdx.x;
+    int index = blockIdx.x*blockDim.x+threadIdx.x + offset;
 
 
     /* 
@@ -303,7 +303,7 @@ void Rosenbrock_ros4(double * __restrict__ conc, const double Tstart, const doub
         for (int i=0; i<NFIX; i++)
             fix(index,i) = conc(index,NVAR+i);
 
-        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO); 
+        update_rconst(var, khet_st, khet_tr, jx, rconst, temp_gpu, press_gpu, cair_gpu, VL_GLO, offset); 
 
         ros_Integrator_ros4(var, fix, Tstart, Tend, Texit,
                 //  Integration parameters
@@ -317,7 +317,7 @@ void Rosenbrock_ros4(double * __restrict__ conc, const double Tstart, const doub
                 K, dFdT, jac0, Ghimj,  varErr, 
                 // For update rconst
                 khet_st, khet_tr, jx,
-                VL_GLO
+                VL_GLO, offset
                 );
 
         for (int i=0; i<NVAR; i++)


### PR DESCRIPTION
This pull request adds streams to medina.

The runtime per iteration on the gpu observed on Kepler (k40m) went from 18s to 13s for the benchmark case

Other architectures were not tested. Perhaps it would be a good idea to do so before merging this.

- #define DEBUG removed in cuda_prototype.cu
- Number of streams (nStreams) set to the number of blocks, perhaps another value would be better for other architectures.